### PR TITLE
add bower.json with dependencies on requirejs-text and mustache

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,14 @@
+{
+  "name": "requirejs-mustache",
+  "version": "0.0.0",
+  "main": "stache.js",
+  "dependencies": {
+    "mustache": ">= 0.1",
+    "requirejs-text": ">= 2.0.0"
+  },
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "components"
+  ]
+}


### PR DESCRIPTION
Hey @jfparadis, thanks for the useful plugin. I'm using [bower](github.com/bower/bower) to manage my dependencies. It would be great if your plugin supported bower. At a minimum, you'd need to create a tag (like `0.0.0`) and merge this PR, and ideally register your plugin with `bower register` as well.
