### PR TITLE
package.json: remove self as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
             "web": "http://jeanfrancoisparadis.com/"
         }
     ],
-    "dependencies": {
-        "http://github.com/jfparadis/requirejs-mustache": "master"
-    },
     "bugs": {
         "url": "https://github.com/jfparadis/requirejs-mustache/issues"
     },


### PR DESCRIPTION
npm was receiving 404 from github when installing requirejs-mistache as a dependency via git url
